### PR TITLE
Set docker buildx context to current directory

### DIFF
--- a/.github/workflows/publish-container.yaml
+++ b/.github/workflows/publish-container.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           build-args: |
             SOURCE_DATE_EPOCH=${{ env.committer_date }}


### PR DESCRIPTION
Otherwise buildx re-clones internally via an additional build context. That clone operation cannot have e.g. submodules disabled. 

Thanks to https://github.com/docker/build-push-action/issues/638#issuecomment-1268196131 for helping me find a simple solution

This change will result in the resulting docker manifests having a different sources array.