### PR TITLE
Dockerfile: LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN find /newroot -newermt "@${SOURCE_DATE_EPOCH}" -writable \
 
 FROM scratch
 
-LABEL org.opencontainers.image.source https://github.com/tkhq/ecr-proxy
+LABEL org.opencontainers.image.source=https://github.com/tkhq/ecr-proxy
 
 COPY --from=builder /newroot /
 


### PR DESCRIPTION
More info: https://docs.docker.com/go/dockerfile/rule/legacy-key-value-format/