### PR TITLE
log proxied requests at debug level

### DIFF
--- a/src/cmd/ecr-proxy/main.go
+++ b/src/cmd/ecr-proxy/main.go
@@ -95,12 +95,18 @@ func main() {
 
 	mux := http.NewServeMux()
 
+	proxyLogger, err := zap.NewStdLogAt(log, zap.DebugLevel)
+	if err != nil {
+		log.Fatal("failed to create a standard logger for the reverse proxy", zap.Error(err))
+	}
+
 	mux.Handle("/v2/", &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			if err := addAuthToken(req); err != nil {
 				log.Error("failed to add auth token to request", zap.Error(err))
 			}
 		},
+		ErrorLog: proxyLogger,
 	})
 
 	mux.HandleFunc("/health", func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
The error logs from ecr-proxy are prodigious.  This reduces the logging level of the proxy error logging to the DEBUG level, also causing it to use the zap logger.